### PR TITLE
docs: Fix line break in directory structure ascii art.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,5 @@ Currently all tests are implemented as unit tests. We use the cmocka library
 to "mock" the interfaces between code modules.
 
 # Source Layout
-./
-├── src  - source code and headers for `libtss2-tcti-uefi.a`
+├── src  - source code and headers for `libtss2-tcti-uefi.a`  
 └── test - unit tests


### PR DESCRIPTION
Takes two spaces at the end of the line to get github to render a line
break.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>