### PR TITLE
build: Fix rules broken by tpm2-tss submodule removal.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,10 +5,7 @@ AM_CFLAGS = -I$(srcdir)/src -I$(srcdir)/tpm2-tss/src -I$(srcdir)/tpm2-tss/includ
 
 TESTS = $(check_PROGRAMS)
 lib_LIBRARIES = src/libtss2-tcti-uefi.a
-noinst_LIBRARIES = \
-    example/libtss2-mu-uefi.a \
-    example/libtss2-sys-uefi.a \
-    test/libtest-util.a
+noinst_LIBRARIES = test/libtest-util.a
 if UNIT
 check_PROGRAMS = \
     test/tcti-uefi-cast_unit \
@@ -48,13 +45,6 @@ EXTRA_DIST = \
 src_libtss2_tcti_uefi_a_CFLAGS = $(EXTRA_CFLAGS) $(AM_CFLAGS)
 src_libtss2_tcti_uefi_a_SOURCES = src/tcg2-util.c src/tcti-uefi.c
 
-# rules to build tpm2-tss libraries for the example uefi application
-example_libtss2_mu_uefi_a_CFLAGS = $(EXTRA_CFLAGS) $(AM_CFLAGS) -DMAXLOGLEVEL=0
-example_libtss2_mu_uefi_a_SOURCES = $(TSS2_MU_C) $(TSS2_UTIL_C)
-
-example_libtss2_sys_uefi_a_CFLAGS = $(EXTRA_CFLAGS) $(AM_CFLAGS) -I$(srcdir)/tpm2-tss/src/tss2-sys/ -DMAXLOGLEVEL=0
-example_libtss2_sys_uefi_a_SOURCES = $(TSS2_SYS_C) $(TSS2_UTIL_C)
-
 # hack to ensure .deps directory required by autotools is created in the
 # 'example' directory before we build any targets
 example/.deps:
@@ -73,7 +63,6 @@ example/tpm2-get-capability.so: LDFLAGS+=-Wl,--no-undefined
 example/tpm2-get-capability.so: LDLIBS+=-l:libtss2-sys.a -l:libtss2-mu.a
 example/tpm2-get-capability.so: \
     example/tpm2-get-capability.o example/tss2-util.o example/compat.o \
-    example/libtss2-sys-uefi.a example/libtss2-mu-uefi.a \
     src/libtss2-tcti-uefi.a
 
 # rule to extract contributors from git history & generate AUTHORS file


### PR DESCRIPTION
This breakage was introduced in bbbbdb26254254e881770608f8b7611d217b2a15
by a bad rebase.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>