### PR TITLE
ci: Remove unnecessary packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ dist: xenial
 addons:
   apt:
     packages:
-      - autoconf-archive
-      - doxygen
       - libcmocka-dev
       - libcmocka0
       - gnulib


### PR DESCRIPTION
We install autoconf-archive manually to get a new version.
tpm2-tss --disable-doxygen-doc dependency issues have been fixed
upstream.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>