### PR TITLE
ci: Run scan-build on clang.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: c
-compiler:
-  - gcc
-  - clang
 dist: xenial
 
 addons:
@@ -17,6 +14,13 @@ env:
     - JOBS="$(($(nproc)*3/2))"
     - PREFIX=/usr
     - MAKE="make --jobs=$JOBS"
+
+matrix:
+  include:
+    - compiler: clang
+      env: SCANBUILD="scan-build --status-bugs"
+    - compiler: gcc
+      env: SCANBUILD=
 
 after_failure:
   - cat tpm2-tcti-uefi-*/_build/sub/test-suite.log
@@ -41,6 +45,6 @@ before_script:
   - ./bootstrap
 
 script:
-  - ./configure --enable-unit
-  - $MAKE distcheck
-  - $MAKE example
+  - $SCANBUILD ./configure --enable-unit
+  - $SCANBUILD $MAKE distcheck
+  - $SCANBUILD $MAKE example

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
     - JOBS="$(($(nproc)*3/2))"
     - PREFIX=/usr
 
+after_failure:
+  - cat tpm2-tcti-uefi-*/_build/sub/test-suite.log
+
 install:
   - wget https://download.01.org/tpm2/autoconf-archive-2017.09.28.tar.xz
   - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01
@@ -38,5 +41,5 @@ before_script:
 
 script:
   - ./configure --enable-unit
-  - make --jobs=${JOBS} distcheck || cat test-suite.log
+  - make --jobs=${JOBS} distcheck
   - make --jobs=${JOBS} example

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   global:
     - JOBS="$(($(nproc)*3/2))"
     - PREFIX=/usr
+    - MAKE="make --jobs=$JOBS"
 
 after_failure:
   - cat tpm2-tcti-uefi-*/_build/sub/test-suite.log
@@ -25,15 +26,15 @@ install:
   - sha256sum autoconf-archive-2017.09.28.tar.xz | grep -q 5c9fb5845b38b28982a3ef12836f76b35f46799ef4a2e46b48e2bd3c6182fa01
   - tar xJf autoconf-archive-2017.09.28.tar.xz && pushd autoconf-archive-2017.09.28
   - ./configure --prefix=${PREFIX}
-  - make --jobs=${JOBS}
-  - sudo make --jobs=${JOBS} install
+  - $MAKE
+  - sudo $MAKE install
   - popd
   - git clone -b master --single-branch https://github.com/tpm2-software/tpm2-tss.git
   - pushd tpm2-tss
   - ./bootstrap --include=/usr/share/gnulib/m4
   - CONFIG_SITE=../lib/tss2-sys_config.site ./configure --prefix=${PREFIX} --disable-defaultflags --disable-doxygen-doc --disable-tcti-device --disable-tcti-mssim --disable-esapi --with-maxloglevel=none
-  - make --jobs=${JOBS}
-  - sudo make --jobs=${JOBS} install
+  - $MAKE
+  - sudo $MAKE install
   - popd
 
 before_script:
@@ -41,5 +42,5 @@ before_script:
 
 script:
   - ./configure --enable-unit
-  - make --jobs=${JOBS} distcheck
-  - make --jobs=${JOBS} example
+  - $MAKE distcheck
+  - $MAKE example

--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,9 @@
 # SPDK-License-Identifier: BSD-2
-AC_INIT([tpm2-uefi],
+AC_INIT([tpm2-tcti-uefi],
         [0.0.0],
-        [https://github.com/tpm2-software/tpm2-uefi/issues],
+        [https://github.com/tpm2-software/tpm2-tcti-uefi/issues],
         [],
-        [https://github.com/tpm2-software/tpm2-uefi])
+        [https://github.com/tpm2-software/tpm2-tcti-uefi])
 # bring canonical names for build tripple, we need target_cpu
 AC_CANONICAL_BUILD
 AC_CANONICAL_HOST


### PR DESCRIPTION
The most simple way to do this is to abandon the 'compiler' JSON
element. Instead we construct the build matrix manually. By doing this
we can define environment varaibles in the matrix more simply. To invoke
scan-build we use an environment variable that is not defined for the
gcc compiler. This prevents us from having to do tricks with the
'exclude' element.

NOTE: When test cases fail, but scan-build doesn't detect issues the
clang build will succeed. This is a bit less than accurate but the gcc
build will fail regardless and the failed tests caught.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>