### PR TITLE
build: Remove clean-local rule for obsolete tss2 build.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 # SPDK-License-Identifier: BSD-2
 #
 .PHONY: example
-AM_CFLAGS = -I$(srcdir)/src -I$(srcdir)/tpm2-tss/src -I$(srcdir)/tpm2-tss/include/tss2
+AM_CFLAGS = -I$(srcdir)/src
 
 TESTS = $(check_PROGRAMS)
 lib_LIBRARIES = src/libtss2-tcti-uefi.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,6 @@ example: \
 
 clean-local:
 	rm -rf $(CLEANS)
-	find tpm2-tss/src -name '*.o' | xargs rm -f
 
 CLEANS = \
     AUTHORS \


### PR DESCRIPTION
This is a hold over from the bad old days when we had to hack up a
special build of the tss2 libraries. We use the CONFIG_SITE file under
lib now and can build directly from the tpm2-tss sources.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>