### PR TITLE
docs: Update travis badge accounting for repo rename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Linux Build Status](https://travis-ci.org/flihp/tpm2-tcti-uefi.svg?branch=master)](https://travis-ci.org/flihp/tpm2-tcti-uefi)
+[![Linux Build Status](https://travis-ci.org/tpm2-software/tpm2-tcti-uefi.svg?branch=master)](https://travis-ci.org/tpm2-software/tpm2-tcti-uefi)
 
 # Overview
 This is an implementation of a TCTI module for use with the TCG TPM2


### PR DESCRIPTION
Repo was moved to tpm2-software github org.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>