### PR TITLE
build: Add integration tests and supporting scripts / data to DIST.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,11 @@ CLEANS = \
     test/tss2-mu-uint32.so
 
 EXTRA_DIST = \
+    lib/efi-test-setup.sh \
+    lib/startup.nsh.template \
+    lib/tss2-sys_config.site \
+    test/hello-world.c \
+    test/tss2-mu-uint32.c \
     AUTHORS \
     CHANGELOG.md \
     CONTRIBUTING.md \


### PR DESCRIPTION
This fixes breakage in the 'distcheck' make target. Since we don't use
libtool to build the *.efi executables we can't use check_PROGRAMS and
so the sources for these binaries aren't distributed. Including them in
the distribution manually is what EXTRA_DIST is for.

The scripts and data under $(srcdir)/lib must be included in the
distribution manually.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>