### PR TITLE
build: Add docker build file based on Ubuntu xenial.

### DIFF
--- a/.ci/build-deps.sh
+++ b/.ci/build-deps.sh
@@ -13,13 +13,15 @@ print_usage ()
 {
     cat <<END
 Usage:
-    $0 --prefix=/usr/local --workdir=/path/to/dir
+    $0 --prefix=/usr/local --edk2-target=/path/to/target.txt --workdir=/path/to/dir
 END
 }
 
 while test $# -gt 0; do
     case $1 in
     -h|--help) print_usage; exit $?;;
+    -e|--edk2-target) EDK2_TARGET=$2; shift;;
+    -e=*|--edk2-target=*) EDK2_TARGET="${1#*=}";;
     -p|--prefix) PREFIX=$2; shift;;
     -p=*|--prefix=*) PREFIX="${1#*=}";;
     -t|--tss2-config-site) TSS2_CONFIG_SITE=$2; shift;;

--- a/Dockerfile-xenial
+++ b/Dockerfile-xenial
@@ -1,0 +1,40 @@
+FROM ubuntu:xenial AS build
+
+ARG PREFIX=/usr
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    bc \
+    build-essential \
+    cpio \
+    iasl \
+    expect \
+    flex \
+    gawk \
+    git \
+    gnulib \
+    libcmocka-dev \
+    libglib2.0-dev \
+    libpixman-1-dev \
+    libssl-dev \
+    libtasn1-dev \
+    libtool \
+    nasm \
+    net-tools \
+    pkg-config \
+    python3 \
+    rpm2cpio \
+    socat \
+    sudo \
+    uuid-dev \
+    wget
+
+WORKDIR /tmp/build-deps
+COPY ./.ci/build-deps.sh ./
+COPY ./.ci/target-ovmf-debug-x64-gcc.txt ./
+COPY ./lib/tss2-sys_config.site ./
+RUN bash -x ./build-deps.sh --prefix=${PREFIX} \
+    --edk2-target=$(pwd)/target-ovmf-debug-x64-gcc.txt \
+    --tss2-config-site=$(pwd)/tss2-sys_config.site


### PR DESCRIPTION
Use this file to build a docker image complete with all build
dependencies. Execute something like the following from the root of the
source tree $(srcdir):

docker image build \
    --file ./Dockerfile-xenial \
    --tag tpm2-tcti-uefi:builder $(pwd)

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>