### PR TITLE
ci: Build OVMF from source.

### DIFF
--- a/.ci/target-ovmf-debug-x64-gcc.txt
+++ b/.ci/target-ovmf-debug-x64-gcc.txt
@@ -1,0 +1,6 @@
+ACTIVE_PLATFORM = OvmfPkg/OvmfPkgX64.dsc
+TARGET = DEBUG
+TARGET_ARCH = X64
+TOOL_CHAIN_CONF = Conf/tools_def.txt
+TOOL_CHAIN_TAG  = GCC5
+BUILD_RULE_CONF = Conf/build_rule.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: c
+python: 2.7
 dist: xenial
 
 addons:
   apt:
     packages:
       - expect
+      - iasl
       - libcmocka-dev
       - libcmocka0
       - gnulib
@@ -12,8 +14,9 @@ addons:
       - libpixman-1-dev
       - libssl-dev
       - libtasn1-dev
-      - rpm2cpio
+      - nasm
       - socat
+      - uuid-dev
 
 env:
   global:


### PR DESCRIPTION
The images previously obtained from kraxel.org are automated weekly
builds. They rotate weekly and so using them is more complex than just
getting the URL right. Building OVMF from source is more reliable.

This commit adds the necessary dependencies to .travis.yml. Building
OVMF is a bit more complicated:
- Firstly the EDK2 build requires bash and so the build-deps.sh script
now uses bash in the shebang.
- The EDK2 build requires a configuration file that we store under
$(srcdir)/lib and copy into the cloned EDK2 sources.
- The compiler used is listed in this file and so we force the use of
GCC for simplicity.
- The way that travis-ci configures python3 is a problem for the EDK2
build and so we disable it in favor of python2.7.
- Finally we find the OVMF.fd file and copy it into place.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>