### PR TITLE
Fix SPDX header string.

### DIFF
--- a/.ci/build-deps.sh
+++ b/.ci/build-deps.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# SPDX-License-Identifier: BSD-2
 set -e
 
 usage_error ()

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-# SPDK-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2
 #
 .PHONY: example
 AM_CFLAGS = -I$(srcdir)/src

--- a/bootstrap
+++ b/bootstrap
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDK-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2
 
 git describe --tags --always --dirty > VERSION
 autoreconf --install --sym

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-# SPDK-License-Identifier: BSD-2
+# SPDX-License-Identifier: BSD-2
 AC_INIT([tpm2-tcti-uefi],
         [0.0.0],
         [https://github.com/tpm2-software/tpm2-tcti-uefi/issues],


### PR DESCRIPTION
This was a typo. 'K' and 'X' look a lot a like I guess.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>