### PR TITLE
configure.ac: tweak usage of AC_ARG_ENABLE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,24 +33,20 @@ AC_CHECK_TOOL([OBJCOPY], objcopy, [AC_MSG_ERROR([Missing required tool: objcopy]
 # unit test library
 AC_ARG_ENABLE([unit],
               [AS_HELP_STRING([--enable-unit],
-                   [build cmocka unit tests (default is no)])],
-              [enable_unit=$enableval],
-              [enable_unit=no])
-AS_IF([test "x$enable_unit" != xno],
+                   [build cmocka unit tests])])
+AS_IF([test "x$enable_unit" = xyes],
       [PKG_CHECK_MODULES([CMOCKA],
                          [cmocka >= 1.0],
                          [AC_DEFINE([HAVE_CMOCKA],
                                     [1],
                                     [cmocka is available])])])
-AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
+AM_CONDITIONAL([UNIT], [test "x$enable_unit" = xyes])
 
 # integration test
 AC_ARG_ENABLE([integration],
               [AS_HELP_STRING([--enable-integration],
-                  [build and run integration tests (default is no)])],
-              [enable_integration=$enableval],
-              [enable_integration=no])
-AS_IF([test "x$enable_integration" != xno],
+                  [build and run integration tests])])
+AS_IF([test "x$enable_integration" = xyes],
       [AC_CHECK_PROG([SWTPM],
                      swtpm,
                      [yes],
@@ -64,7 +60,7 @@ AS_IF([test "x$enable_integration" != xno],
                                    [Path to OVMF.fd]),
                    [AC_SUBST([OVMF_PATH],[$withval])],
                    [AC_SUBST([OVMF_PATH],[/usr/share/ovmf/OVMF.fd])])])
-AM_CONDITIONAL([INTEGRATION], [test "x$enable_integration" != xno])
+AM_CONDITIONAL([INTEGRATION], [test "x$enable_integration" = xyes])
 
 # directory where gnu-efi headers live
 AC_ARG_WITH([efi-includedir],


### PR DESCRIPTION
For AC_ARG_ENABLE(x, y, ACTION-IF-FOUND, ACTION-IF-NOT-FOUND), when ACTION-IF-FOUND and ACTION-IF-NOT-FOUND are not provided, that is AC_ARG_ENABLE(x, y) is in configure.ac, and
* “./configure” is called, the variable enable_x is not set, that is ${enable_x+set} != set;
* "./configure --enable-x" is called, the variable enable_x is set to "yes";
* "./configure --disable-x" is called, the variable enable_x is set to "no".

For features disabled by default, the only thing that matters is, if the user calls “./configure --enable-x”, that is, if enable_x is "yes".  enable_x being not set, or being "no" is the same state.

On “./configure --help” printing “--enable-x” implies that feature X is disabled by default and the help instructs the user how to enable the feature.  Printing --disable-X would imply the opposite.