### PR TITLE
build: Remove use of 'timeout' when launching qemu in test harness.

### DIFF
--- a/lib/efi-test-setup.sh
+++ b/lib/efi-test-setup.sh
@@ -58,7 +58,7 @@ swtpm socket --tpm2 --tpmstate dir=${TMP_DIR} \
     --ctrl type=unixio,path=${TMP_DIR}/tpm-sock \
     --log file=${TMP_DIR}/${TEST_NAME}_swtpm.log,level=20 &
 
-timeout 30s unbuffer qemu-system-x86_64 \
+qemu-system-x86_64 \
     -nographic \
     --bios ${OVMF_FD} \
     -drive file=fat:rw:${TMP_DIR} \


### PR DESCRIPTION
Originally the 'timeout' utility was used to kill qemu off after each
integration test. This measure was a workaround for my not knowing how
to properly terminate the emulator after a test completed. The uefi
shell template used to create the startup.nsh script now uses the uefi
shell 'reset' command after each test to power off qemu. The use of
'timeout' is redundant.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>