### PR TITLE
ci: Disable seccomp when building swtpm

### DIFF
--- a/.ci/build-deps.sh
+++ b/.ci/build-deps.sh
@@ -82,7 +82,7 @@ CC=gcc
 git clone --branch master --single-branch \
   https://github.com/stefanberger/swtpm
 cd swtpm
-./autogen.sh --prefix=${PREFIX}
+./autogen.sh --prefix=${PREFIX} --without-seccomp
 $MAKE
 sudo $MAKE install
 cd -


### PR DESCRIPTION
Seccomp was added to swtpm and it is enabled by default. To build
without it requires disabling it explicitly.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>