### PR TITLE
example: Add tool to dump the preboot eventlog.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -50,12 +50,15 @@ all-local: AUTHORS
 
 example: \
     example/tcg2-get-caps.efi \
+    example/tcg2-get-eventlog.efi \
     example/tpm2-get-caps-fixed.efi
 
 CLEANS = \
     AUTHORS \
     example/tcg2-get-caps.efi \
     example/tcg2-get-caps.so \
+    example/tcg2-get-eventlog.efi \
+    example/tcg2-get-eventlog.so \
     example/tpm2-get-caps-fixed.efi \
     example/tpm2-get-caps-fixed.so \
     example/*.$(OBJEXT) \
@@ -90,6 +93,8 @@ example/.deps:
 test/hello-world.$(OBJEXT): test/hello-world.c | example/.deps
 example/tcg2-get-caps.$(OBJEXT): example/tcg2-get-caps.c \
     src/tcg2-protocol.h src/tcg2-util.h | example/.deps
+example/tcg2-get-eventlog.$(OBJEXT): example/tcg2-get-eventlog.c \
+    |example/.deps
 example/tpm2-get-caps-fixed.$(OBJEXT): example/tpm2-get-caps-fixed.c \
     example/compat.h example/tss2-util.h | example/.deps
 test/tss2-mu-uint32.$(OBJEXT): test/tss2-mu-uint32.c | example/.deps
@@ -98,6 +103,10 @@ test/tss2-mu-uint32.$(OBJEXT): test/tss2-mu-uint32.c | example/.deps
 example/tcg2-get-caps.so: CFLAGS+=$(EXTRA_CFLAGS) $(AM_CFLAGS)
 example/tcg2-get-caps.so: LDFLAGS+=-Wl,--no-undefined
 example/tcg2-get-caps.so: example/tcg2-get-caps.o src/tcg2-util.o
+
+example/tcg2-get-eventlog.so: CFLAGS+=$(EXTRA_CFLAGS) $(AM_CFLAGS)
+example/tcg2-get-eventlog.so: LDFLAGS+=-Wl,--no-undefined
+example/tcg2-get-eventlog.so: example/tcg2-get-eventlog.o src/tcg2-util.o
 
 example/tpm2-get-caps-fixed.so: CFLAGS+=$(EXTRA_CFLAGS) $(AM_CFLAGS)
 example/tpm2-get-caps-fixed.so: LDFLAGS+=-Wl,--no-undefined

--- a/example/tcg2-get-eventlog.c
+++ b/example/tcg2-get-eventlog.c
@@ -1,0 +1,154 @@
+/* SPDX-License-Identifier: BSD-2 */
+#include <efi/efi.h>
+#include <efi/efilib.h>
+
+#include <inttypes.h>
+#include <stdlib.h>
+
+#include "tcg2-protocol.h"
+#include "tcg2-util.h"
+
+static CHAR16*
+eventtype_to_string (TCG_EVENTTYPE event_type)
+{
+    switch (event_type) {
+    case EV_PREBOOT_CERT:
+        return L"EV_PREBOOT_CERT";
+    case EV_POST_CODE:
+        return L"EV_POST_CODE";
+    case EV_UNUSED:
+        return L"EV_UNUSED";
+    case EV_NO_ACTION:
+        return L"EV_NO_ACTION";
+    case EV_SEPARATOR:
+        return L"EV_SEPARATOR";
+    case EV_ACTION:
+        return L"EV_ACTION";
+    case EV_EVENT_TAG:
+        return L"EV_EVENT_TAG";
+    case EV_S_CRTM_CONTENTS:
+        return L"EV_S_CRTM_CONTENTS";
+    case EV_S_CRTM_VERSION:
+        return L"EV_S_CRTM_VERSION";
+    case EV_CPU_MICROCODE:
+        return L"EV_CPU_MICROCODE";
+    case EV_PLATFORM_CONFIG_FLAGS:
+        return L"EV_PLATFORM_CONFIG_FLAGS";
+    case EV_TABLE_OF_DEVICES:
+        return L"EV_TABLE_OF_DEVICES";
+    case EV_COMPACT_HASH:
+        return L"EV_COMPACT_HASH";
+    case EV_IPL:
+        return L"EV_IPL";
+    case EV_IPL_PARTITION_DATA:
+        return L"EV_IPL_PARTITION_DATA";
+    case EV_NONHOST_CODE:
+        return L"EV_NONHOST_CODE";
+    case EV_NONHOST_CONFIG:
+        return L"EV_NONHOST_CONFIG";
+    case EV_NONHOST_INFO:
+        return L"EV_NONHOST_INFO";
+    case EV_OMIT_BOOT_DEVICE_EVENTS:
+        return L"EV_OMIT_BOOT_DEVICE_EVENTS";
+    case EV_EFI_VARIABLE_DRIVER_CONFIG:
+        return L"EV_EFI_VARIABLE_DRIVER_CONFIG";
+    case EV_EFI_VARIABLE_BOOT:
+        return L"EV_EFI_VARIABLE_BOOT";
+    case EV_EFI_BOOT_SERVICES_APPLICATION:
+        return L"EV_EFI_BOOT_SERVICES_APPLICATION";
+    case EV_EFI_BOOT_SERVICES_DRIVER:
+        return L"EV_EFI_BOOT_SERVICES_DRIVER";
+    case EV_EFI_RUNTIME_SERVICES_DRIVER:
+        return L"EV_EFI_RUNTIME_SERVICES_DRIVER";
+    case EV_EFI_GPT_EVENT:
+        return L"EV_EFI_GPT_EVENT";
+    case EV_EFI_ACTION:
+        return L"EV_EFI_ACTION";
+    case EV_EFI_PLATFORM_FIRMWARE_BLOB:
+        return L"EV_EFI_PLATFORM_FIRMWARE_BLOB";
+    case EV_EFI_HANDOFF_TABLES:
+        return L"EV_EFI_HANDOFF_TABLES";
+    case EV_EFI_VARIABLE_AUTHORITY:
+        return L"EV_EFI_VARIABLE_AUTHORITY";
+    default:
+        return L"Unknown event type";
+    }
+}
+static void
+prettyprint_tpm12_event (TCG_PCR_EVENT *event)
+{
+    Print (L"TCG_PCR_EVENT: 0x%" PRIxPTR "\n", (uintptr_t)event);
+    Print (L"  PCRIndex: %d\n", event->PCRIndex);
+    Print (L"  EventType: %s (0x%08" PRIx32 ")\n",
+           eventtype_to_string (event->EventType),
+           event->EventType);
+    Print (L"  digest: \n");
+    DumpHex (4, 0, sizeof (event->digest), &event->digest);
+    Print (L"  EventSize: %d\n", event->EventSize);
+    Print (L"  Event: \n");
+    DumpHex (4, 0, event->EventSize, event->Event);
+}
+static TCG_PCR_EVENT*
+tpm12_event_next (TCG_PCR_EVENT *current,
+                  TCG_PCR_EVENT *last)
+{
+    TCG_PCR_EVENT *next;
+
+    if (current == last)
+        return NULL;
+
+    next = (TCG_PCR_EVENT*)((char*)(current + 1) + current->EventSize - 1);
+    if (next > last) {
+        Print (L"Error: current element is beyond the end of the log\n");
+        return NULL;
+    }
+
+    return next;
+}
+static void
+prettyprint_tpm12_eventlog (EFI_PHYSICAL_ADDRESS first,
+                            EFI_PHYSICAL_ADDRESS last)
+{
+    TCG_PCR_EVENT *event_last, *event;
+
+    event = (TCG_PCR_EVENT*) first;
+    event_last  = (TCG_PCR_EVENT*) last;
+
+    if (event == NULL) {
+        Print (L"TPM2 EventLog is empty.");
+        return;
+    }
+
+    Print (L"TPM2 EventLog, EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2 format\n");
+    do {
+        prettyprint_tpm12_event (event);
+    } while ((event = tpm12_event_next (event, event_last)) != NULL);
+}
+EFI_STATUS EFIAPI
+efi_main (
+    EFI_HANDLE ImageHandle,
+    EFI_SYSTEM_TABLE *SystemTable
+    )
+{
+    EFI_TCG2_PROTOCOL *tcg2_protocol;
+    EFI_STATUS status;
+    EFI_PHYSICAL_ADDRESS first, last;
+    EFI_TCG2_EVENT_LOG_FORMAT format = EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2;
+    BOOLEAN trunc;
+
+    InitializeLib (ImageHandle, SystemTable);
+    status = tcg2_get_protocol (&tcg2_protocol);
+    if (EFI_ERROR (status))
+        return status;
+
+    status = tcg2_get_eventlog (tcg2_protocol, format, &first, &last, &trunc);
+    if (EFI_ERROR (status))
+        return status;
+
+    if (trunc)
+        Print (L"WARNING: Eventlog has been truncated\n");
+
+    prettyprint_tpm12_eventlog (first, last);
+
+    return status;
+}

--- a/src/tcg2-protocol.h
+++ b/src/tcg2-protocol.h
@@ -17,6 +17,7 @@
 
 typedef UINT32 TCG_PCRINDEX;
 typedef UINT32 TCG_EVENTTYPE;
+typedef UINT8 TCG_DIGEST [20];
 
 typedef UINT32 EFI_TCG2_EVENT_LOG_BITMAP;
 typedef UINT32 EFI_TCG2_EVENT_LOG_FORMAT;
@@ -38,6 +39,46 @@ typedef UINT32 EFI_TCG2_EVENT_ALGORITHM_BITMAP;
 #define EFI_TCG2_BOOT_HASH_ALG_SHA512  0x00000008
 #define EFI_TCG2_BOOT_HASH_ALG_SM3_256 0x00000010
 
+/*
+ * Log event types. These are spread out over 2 specs:
+ * "TCG EFI Protocol Specification For TPM Family 1.1 or 1.2" and
+ * "TCG PC Client Specific Implementation Specification for Conventional BIOS"
+ */
+#define EV_PREBOOT_CERT            0x0
+#define EV_POST_CODE               0x1
+#define EV_UNUSED                  0x2
+#define EV_NO_ACTION               0x3
+#define EV_SEPARATOR               0x4
+#define EV_ACTION                  0x5
+#define EV_EVENT_TAG               0x6
+#define EV_S_CRTM_CONTENTS         0x7
+#define EV_S_CRTM_VERSION          0x8
+#define EV_CPU_MICROCODE           0x9
+#define EV_PLATFORM_CONFIG_FLAGS   0xa
+#define EV_TABLE_OF_DEVICES        0xb
+#define EV_COMPACT_HASH            0xc
+#define EV_IPL                     0xd
+#define EV_IPL_PARTITION_DATA      0xe
+#define EV_NONHOST_CODE            0xf
+#define EV_NONHOST_CONFIG          0x10
+#define EV_NONHOST_INFO            0x11
+#define EV_OMIT_BOOT_DEVICE_EVENTS 0x12
+
+/*
+ * TCG EFI Platform Specification For TPM Family 1.1 or 1.2
+ */
+#define EV_EFI_EVENT_BASE                0x80000000
+#define EV_EFI_VARIABLE_DRIVER_CONFIG    EV_EFI_EVENT_BASE + 0x1
+#define EV_EFI_VARIABLE_BOOT             EV_EFI_EVENT_BASE + 0x2
+#define EV_EFI_BOOT_SERVICES_APPLICATION EV_EFI_EVENT_BASE + 0x3
+#define EV_EFI_BOOT_SERVICES_DRIVER      EV_EFI_EVENT_BASE + 0x4
+#define EV_EFI_RUNTIME_SERVICES_DRIVER   EV_EFI_EVENT_BASE + 0x5
+#define EV_EFI_GPT_EVENT                 EV_EFI_EVENT_BASE + 0x6
+#define EV_EFI_ACTION                    EV_EFI_EVENT_BASE + 0x7
+#define EV_EFI_PLATFORM_FIRMWARE_BLOB    EV_EFI_EVENT_BASE + 0x8
+#define EV_EFI_HANDOFF_TABLES            EV_EFI_EVENT_BASE + 0x9
+#define EV_EFI_VARIABLE_AUTHORITY        EV_EFI_EVENT_BASE + 0xe0
+
 #ifndef PACKED
 #define PACKED __attribute__((__packed__))
 #endif
@@ -45,6 +86,14 @@ typedef UINT32 EFI_TCG2_EVENT_ALGORITHM_BITMAP;
 typedef struct tdEFI_TCG2_PROTOCOL EFI_TCG2_PROTOCOL;
 
 /* structures */
+typedef struct {
+  TCG_PCRINDEX  PCRIndex;
+  TCG_EVENTTYPE EventType;
+  TCG_DIGEST    digest;
+  UINT32        EventSize;
+  UINT8         Event[1];
+} PACKED TCG_PCR_EVENT;
+
 typedef struct tdEFI_TCG2_EVENT_HEADER {
   UINT32        HeaderSize;
   UINT16        HeaderVersion;

--- a/src/tcg2-util.c
+++ b/src/tcg2-util.c
@@ -7,6 +7,29 @@
 #include "tcg2-protocol.h"
 
 EFI_STATUS EFIAPI
+tcg2_get_eventlog (EFI_TCG2_PROTOCOL *tpm2_prot,
+                   EFI_TCG2_EVENT_LOG_FORMAT format,
+                   EFI_PHYSICAL_ADDRESS *first,
+                   EFI_PHYSICAL_ADDRESS *last,
+                   BOOLEAN *truncated)
+{
+    EFI_STATUS status;
+
+    status = uefi_call_wrapper (tpm2_prot->GetEventLog,
+                                5,
+                                tpm2_prot,
+                                format,
+                                first,
+                                last,
+                                truncated);
+    if (EFI_ERROR (status)) {
+        Print (L"Tcg2 SubmitCommand failed: 0x%x\n", status);
+    }
+
+    return status;
+}
+
+EFI_STATUS EFIAPI
 tcg2_get_capability (
     EFI_TCG2_PROTOCOL *tcg2_protocol,
     EFI_TCG2_BOOT_SERVICE_CAPABILITY *tcg2_bs_caps

--- a/src/tcg2-util.h
+++ b/src/tcg2-util.h
@@ -7,6 +7,12 @@
 #include "tcg2-protocol.h"
 
 EFI_STATUS EFIAPI
+tcg2_get_eventlog (EFI_TCG2_PROTOCOL *tpm2_prot,
+                   EFI_TCG2_EVENT_LOG_FORMAT format,
+                   EFI_PHYSICAL_ADDRESS *first,
+                   EFI_PHYSICAL_ADDRESS *last,
+                   BOOLEAN *truncated);
+EFI_STATUS EFIAPI
 tcg2_get_capability (EFI_TCG2_PROTOCOL *tcg2_protocol,
                      EFI_TCG2_BOOT_SERVICE_CAPABILITY *tcg2_bs_caps);
 void EFIAPI


### PR DESCRIPTION
The current implementation is limited to the version 1.2 log format.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>