### PR TITLE
tcg2-protocol: Change 'digest' member of TCG_PCR_EVENT to 'Digest'.

### DIFF
--- a/example/tcg2-get-eventlog.c
+++ b/example/tcg2-get-eventlog.c
@@ -19,8 +19,8 @@ prettyprint_tpm12_event (TCG_PCR_EVENT *event)
     Print (L"  EventType: %s (0x%08" PRIx32 ")\n",
            eventtype_to_string (event->EventType),
            event->EventType);
-    Print (L"  digest: \n");
-    DumpHex (4, 0, sizeof (event->digest), &event->digest);
+    Print (L"  Digest: \n");
+    DumpHex (4, 0, sizeof (event->Digest), &event->Digest);
     Print (L"  EventSize: %d\n", event->EventSize);
     Print (L"  Event: \n");
     DumpHex (4, 0, event->EventSize, event->Event);

--- a/src/tcg2-protocol.h
+++ b/src/tcg2-protocol.h
@@ -89,7 +89,7 @@ typedef struct tdEFI_TCG2_PROTOCOL EFI_TCG2_PROTOCOL;
 typedef struct {
   TCG_PCRINDEX  PCRIndex;
   TCG_EVENTTYPE EventType;
-  TCG_DIGEST    digest;
+  TCG_DIGEST    Digest;
   UINT32        EventSize;
   UINT8         Event[1];
 } PACKED TCG_PCR_EVENT;


### PR DESCRIPTION
An older version of the 'TrEE' protocol spec has this typo and this
structure followed the spec, including the type. This has been fixed
upstream, and now fixed here.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>

This resolves #59 