### PR TITLE
build: Have git ignore the files generated for the code coverage report.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ test-suite.log
 VERSION
 src/get-capability.efi
 test/*_unit
+tpm2-tcti-uefi-*-coverage*


### PR DESCRIPTION
Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>