### PR TITLE
ci: Switch from coveralls to codecov.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+ - "test"
+ - "example"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,8 @@ after_failure:
 
 after_success:
   - |
-    if [ ! -z "$COVERALLS_REPO_TOKEN" ] && [ "${CC}" = "gcc" ]; then
-      coveralls --build-root=$(pwd) --exclude=./example --exclude=./test \
-        --gcov-options '\-lp'
+    if [ "${CONFIG_EXTRA}" == "--enable-code-coverage" ]; then
+        bash <(curl -s https://codecov.io/bash)
     fi
 
 install:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Linux Build Status](https://travis-ci.org/tpm2-software/tpm2-tcti-uefi.svg?branch=master)](https://travis-ci.org/tpm2-software/tpm2-tcti-uefi)
-[![Coverage Status](https://coveralls.io/repos/github/tpm2-software/tpm2-tcti-uefi/badge.svg?branch=master)](https://coveralls.io/github/tpm2-software/tpm2-tcti-uefi?branch=master)
+[![codecov](https://codecov.io/gh/tpm2-software/tpm2-tcti-uefi/branch/master/graph/badge.svg)](https://codecov.io/gh/tpm2-software/tpm2-tcti-uefi)
 
 # Overview
 This is an implementation of a TCTI module for use with the TCG TPM2


### PR DESCRIPTION
Most of the other tpm2-software repos have already made the switch.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>