### PR TITLE
Foreach event

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -168,11 +168,11 @@ AUTHORS :
 # variables to simplify test rules
 TEST_FLAGS = $(CMOCKA_CFLAGS) $(EXTRA_CFLAGS) $(AM_CFLAGS) \
     $(CODE_COVERAGE_CFLAGS)
-TEST_LIBS = $(CMOCKA_LIBS) $(CODE_COVERAGE_LIBS) src/libtss2-tcti-uefi.a \
-    test/libtest-util.a
+TEST_LIBS = $(libexample_util) $(CMOCKA_LIBS) $(CODE_COVERAGE_LIBS) \
+    src/libtss2-tcti-uefi.a test/libtest-util.a
 TEST_WRAPS_TCTI = -Wl,--wrap=AllocatePool,--wrap=CopyMem,--wrap=FreePool \
     -Wl,--wrap=Print,--wrap=tcg2_get_capability,--wrap=tcg2_get_max_buf \
-    -Wl,--wrap=tcg2_get_protocol,--wrap=tcg2_submit_command
+    -Wl,--wrap=tcg2_get_protocol,--wrap=tcg2_submit_command,--wrap=DumpHex
 TEST_WRAPS_TCG2 = -Wl,--wrap=AllocatePool,--wrap=CopyMem \
     -Wl,--wrap=FreePool,--wrap=Print,--wrap=efi_call2,--wrap=efi_call5 \
     -Wl,--wrap=LibLocateProtocol
@@ -184,7 +184,7 @@ test_libtest_util_a_SOURCES = test/tcti-uefi-wraps.c test/tcti-uefi-wraps.h
 
 # rules to build test executables
 test_example_util_unit_CFLAGS = $(TEST_FLAGS) -DGNU_EFI_SETJMP_H
-test_example_util_unit_LDADD = $(libexample_util) $(TEST_LIBS)
+test_example_util_unit_LDADD = $(TEST_LIBS)
 test_example_util_unit_LDFLAGS = $(TEST_WRAPS_TCTI)
 test_example_util_unit_SOURCES = test/example-util_unit.c
 

--- a/example/tcg2-get-eventlog.c
+++ b/example/tcg2-get-eventlog.c
@@ -67,7 +67,6 @@ prettyprint_tpm2_eventlog (EFI_PHYSICAL_ADDRESS first,
 {
     TCG_EVENT_HEADER2 *event = (TCG_EVENT_HEADER2*)first;
     TCG_EVENT_HEADER2 *event_last = (TCG_EVENT_HEADER2*)last;
-    size_t i;
 
     if (event == NULL) {
         Print (L"TPM2 EventLog is empty.\n");
@@ -75,10 +74,7 @@ prettyprint_tpm2_eventlog (EFI_PHYSICAL_ADDRESS first,
     }
 
     Print (L"TPM2 EventLog, EFI_TCG2_EVENT_LOG_FORMAT_TCG_2 format\n");
-    for (i = 0; event <= event_last; ++i) {
-        Print (L"EVENT: %" PRIu32 "\n", i);
-        event = prettyprint_tpm2_event (event);
-    }
+    foreach_event2 (event, event_last, prettyprint_tpm2_event_callback, NULL);
     Print (L"TPM2 EventLog end\n");
 }
 static void

--- a/example/tcg2-get-eventlog.c
+++ b/example/tcg2-get-eventlog.c
@@ -62,52 +62,6 @@ prettyprint_tpm12_eventlog (EFI_PHYSICAL_ADDRESS first,
     } while ((event = tpm12_event_next (event, event_last)) != NULL);
 }
 static void
-prettyprint_tpm2_eventbuf (TCG_EVENT2 *event)
-{
-    Print (L"  Event: %" PRIu32 " bytes\n", event->EventSize);
-    DumpHex (2, 0, event->EventSize, event->Event);
-}
-static void
-prettyprint_tpm2_digest (TCG_DIGEST2 *digest)
-{
-    size_t digest_size;
-
-    Print (L"    AlgorithmId: %s (0x%" PRIx16 ")\n",
-           get_alg_name (digest->AlgorithmId), digest->AlgorithmId);
-    /* map alg id to alg size to get buffer size */
-    digest_size = get_alg_size (digest->AlgorithmId);
-    Print (L"    Digest: %d bytes\n", digest_size);
-    DumpHex (4, 0, digest_size, digest->Digest);
-}
-static void
-prettyprint_tpm2_event_header (TCG_EVENT_HEADER2 *event_hdr)
-{
-    Print (L"  PCRIndex: %d\n", event_hdr->PCRIndex);
-    Print (L"  EventType: %s (0x%" PRIx32 ")\n",
-           eventtype_to_string (event_hdr->EventType),
-           event_hdr->EventType);
-    Print (L"  DigestCount: %d\n", event_hdr->DigestCount);
-}
-static TCG_EVENT_HEADER2*
-prettyprint_tpm2_event (TCG_EVENT_HEADER2 *event_hdr)
-{
-    TCG_DIGEST2 *digest;
-    TCG_EVENT2 *event;
-    size_t i;
-
-    prettyprint_tpm2_event_header (event_hdr);
-    digest = (TCG_DIGEST2*)event_hdr->Digests;
-    for (i = 0; i < event_hdr->DigestCount; ++i) {
-        Print (L"  TCG_DIGEST2: %u\n", i);
-        prettyprint_tpm2_digest (digest);
-        digest = get_next_digest (digest);
-    }
-    event = (TCG_EVENT2*)digest;
-    prettyprint_tpm2_eventbuf (event);
-
-    return (TCG_EVENT_HEADER2*)(event->Event + event->EventSize);
-}
-static void
 prettyprint_tpm2_eventlog (EFI_PHYSICAL_ADDRESS first,
                            EFI_PHYSICAL_ADDRESS last)
 {

--- a/example/util.h
+++ b/example/util.h
@@ -43,3 +43,11 @@ count_algs_in_bitmap (EFI_TCG2_EVENT_ALGORITHM_BITMAP bitmap);
 void EFIAPI
 select_all_active_pcrs (EFI_TCG2_EVENT_ALGORITHM_BITMAP active_banks,
                         TPML_PCR_SELECTION *selections);
+void
+prettyprint_tpm2_digest (TCG_DIGEST2 *digest);
+void
+prettyprint_tpm2_event_header (TCG_EVENT_HEADER2 *event_hdr);
+void
+prettyprint_tpm2_eventbuf (TCG_EVENT2 *event);
+TCG_EVENT_HEADER2*
+prettyprint_tpm2_event (TCG_EVENT_HEADER2 *event_hdr);

--- a/example/util.h
+++ b/example/util.h
@@ -45,9 +45,21 @@ select_all_active_pcrs (EFI_TCG2_EVENT_ALGORITHM_BITMAP active_banks,
                         TPML_PCR_SELECTION *selections);
 void
 prettyprint_tpm2_digest (TCG_DIGEST2 *digest);
+bool
+prettyprint_tpm2_digest_callback (TCG_DIGEST2 *digest,
+                                  void *data);
 void
 prettyprint_tpm2_event_header (TCG_EVENT_HEADER2 *event_hdr);
 void
 prettyprint_tpm2_eventbuf (TCG_EVENT2 *event);
 TCG_EVENT_HEADER2*
 prettyprint_tpm2_event (TCG_EVENT_HEADER2 *event_hdr);
+
+typedef bool (*DIGEST2_CALLBACK) (TCG_DIGEST2 *digest,
+                                  void *data);
+bool
+foreach_digest2 (TCG_EVENT_HEADER2 *event_hdr,
+                 DIGEST2_CALLBACK callback,
+                 void *data);
+size_t
+sizeof_digest2 (TCG_DIGEST2 *digest);

--- a/example/util.h
+++ b/example/util.h
@@ -52,8 +52,11 @@ void
 prettyprint_tpm2_event_header (TCG_EVENT_HEADER2 *event_hdr);
 void
 prettyprint_tpm2_eventbuf (TCG_EVENT2 *event);
-TCG_EVENT_HEADER2*
+void
 prettyprint_tpm2_event (TCG_EVENT_HEADER2 *event_hdr);
+bool
+prettyprint_tpm2_event_callback (TCG_EVENT_HEADER2 *event_hdr,
+                                 void *data);
 
 typedef bool (*DIGEST2_CALLBACK) (TCG_DIGEST2 *digest,
                                   void *data);
@@ -61,5 +64,11 @@ bool
 foreach_digest2 (TCG_EVENT_HEADER2 *event_hdr,
                  DIGEST2_CALLBACK callback,
                  void *data);
-size_t
-sizeof_digest2 (TCG_DIGEST2 *digest);
+
+typedef bool (*EVENT2_CALLBACK) (TCG_EVENT_HEADER2 *event_hdr,
+                                 void *data);
+bool
+foreach_event2 (TCG_EVENT_HEADER2 *event_hdr,
+                TCG_EVENT_HEADER2 *last_hdr,
+                EVENT2_CALLBACK callback,
+                void *data);

--- a/test/tcti-uefi-wraps.c
+++ b/test/tcti-uefi-wraps.c
@@ -115,3 +115,11 @@ __wrap_LibLocateProtocol (IN  EFI_GUID *ProtocolGuid,
     *Interface = mock_type (void*);
     return mock_type (EFI_STATUS);
 }
+VOID
+__wrap_DumpHex (IN UINTN Indent,
+                IN UINTN Offset,
+                IN UINTN DataSize,
+                IN VOID *UserData)
+{
+    Print ("%s\n", __func__);
+}

--- a/test/tcti-uefi-wraps.h
+++ b/test/tcti-uefi-wraps.h
@@ -46,5 +46,10 @@ __wrap_tcg2_submit_command (EFI_TCG2_PROTOCOL *tcg2_protocol,
                             UINT8 *input_buf,
                             UINT32 output_size,
                             UINT8 *output_buf);
+VOID
+__wrap_DumpHex (IN UINTN Indent,
+                IN UINTN Offset,
+                IN UINTN DataSize,
+                IN VOID *UserData);
 
 #endif /* TCTI_UEFI_WRAPS_H */


### PR DESCRIPTION
Restructure log / event / digest parsing to use a 'foreach' callback pattern. Expose these functions in the example library.