### PR TITLE
example: Update tss2 constants to account for upstream fix.

### DIFF
--- a/example/tpm2-get-caps-fixed.c
+++ b/example/tpm2-get-caps-fixed.c
@@ -136,11 +136,11 @@ dump_tpm_properties_fixed (TPMS_TAGGED_PROPERTY properties[],
             Print (L"TPM2_PT_INPUT_BUFFER:\n"
                     "  value: 0x%X\n", value);
             break;
-        case TPM2_PT_TPM2_HR_TRANSIENT_MIN:
+        case TPM2_PT_HR_TRANSIENT_MIN:
             Print (L"TPM2_PT_TPM2_HR_TRANSIENT_MIN:\n"
                     "  value: 0x%X\n", value);
             break;
-        case TPM2_PT_TPM2_HR_PERSISTENT_MIN:
+        case TPM2_PT_HR_PERSISTENT_MIN:
             Print (L"TPM2_PT_TPM2_HR_PERSISTENT_MIN:\n"
                     "  value: 0x%X\n", value);
             break;


### PR DESCRIPTION
A few of the constants from the tss2 headers had an extra 'TPM2' in them
this was addressed upstream in 7b2dc9e2e1f4b44df073643075c24f74a0187211.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>