### PR TITLE
example: Remove functions duplicated in tcg2-util module.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -146,8 +146,7 @@ example/tpm2-get-pcrs.so: example/tpm2-get-pcrs.$(OBJEXT)
 
 example/tcg2-get-pcr-banks.so: CFLAGS+=$(EXTRA_CFLAGS) $(AM_CFLAGS)
 example/tcg2-get-pcr-banks.so: LDFLAGS+=-Wl,--no-undefined
-example/tcg2-get-pcr-banks.so: LDLIBS+=-l:libtss2-sys.a -l:libtss2-mu.a \
-    $(CODE_COVERAGE_LIBS)
+example/tcg2-get-pcr-banks.so: LDLIBS+=$(CODE_COVERAGE_LIBS)
 example/tcg2-get-pcr-banks.so: $(libexample_util) $(libtss2_tcti_uefi)
 example/tcg2-get-pcr-banks.so: example/tcg2-get-pcr-banks.$(OBJEXT)
 

--- a/example/tcg2-get-pcr-banks.c
+++ b/example/tcg2-get-pcr-banks.c
@@ -5,38 +5,10 @@
 #include <efi/efi.h>
 #include <efi/efilib.h>
 
-#include <tss2/tss2_mu.h>
-#include <tss2/tss2_sys.h>
-
 #include "tcg2-util.h"
 
 #define TRUE_STR L"true"
 #define FALSE_STR L"false"
-
-WCHAR*
-bitmap_val_str (UINT32 member, UINT32 selector)
-{
-    if (member & selector) {
-        return TRUE_STR;
-    } else {
-        return FALSE_STR;
-    }
-}
-
-void EFIAPI
-tcg2_algorithm_bitmap_prettyprint (EFI_TCG2_EVENT_ALGORITHM_BITMAP bitmap)
-{
-    Print (L"    EFI_TCG2_BOOT_HASH_ALG_SHA1: %s\n",
-        bitmap_val_str (bitmap, EFI_TCG2_BOOT_HASH_ALG_SHA1));
-    Print (L"    EFI_TCG2_BOOT_HASH_ALG_SHA256: %s\n",
-        bitmap_val_str (bitmap, EFI_TCG2_BOOT_HASH_ALG_SHA256));
-    Print (L"    EFI_TCG2_BOOT_HASH_ALG_SHA384: %s\n",
-        bitmap_val_str (bitmap, EFI_TCG2_BOOT_HASH_ALG_SHA384));
-    Print (L"    EFI_TCG2_BOOT_HASH_ALG_SHA512: %s\n",
-        bitmap_val_str (bitmap, EFI_TCG2_BOOT_HASH_ALG_SHA512));
-    Print (L"    EFI_TCG2_BOOT_HASH_ALG_SM3_256: %s\n",
-        bitmap_val_str (bitmap, EFI_TCG2_BOOT_HASH_ALG_SM3_256));
-}
 
 EFI_STATUS EFIAPI
 efi_main (


### PR DESCRIPTION
This removes the dependency on the tss2 headers. The build is updated to
remove the dependencies on the tss2 libraries as well. This was never
required.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>