### PR TITLE
Use EFIAPI appropriately.

### DIFF
--- a/.ci/build-deps.sh
+++ b/.ci/build-deps.sh
@@ -104,8 +104,10 @@ $MAKE
 sudo $MAKE install
 cd -
 
-GNUEFI_BZ2=gnu-efi-3.0.9.tar.bz2
-GNUEFI_BZ2_SHA256=6715ea7eae1c7e4fc5041034bd3f107ec2911962ed284a081e491646b12277f0
+GNUEFI_VERSION=3.0.10
+GNUEFI_NAME=gnu-efi-${GNUEFI_VERSION}
+GNUEFI_BZ2=$GNUEFI_NAME.tar.bz2
+GNUEFI_BZ2_SHA256=f12082a3a5f0c3e38c67262a9f34245d139ac2cdfc0a0bdcf03c9b1f56fa4fed
 wget "https://downloads.sourceforge.net/project/gnu-efi/${GNUEFI_BZ2}"
 sha256sum "${GNUEFI_BZ2}" | grep -q "${GNUEFI_BZ2_SHA256}"
 if [ ! $? -eq 0 ]; then
@@ -113,7 +115,7 @@ if [ ! $? -eq 0 ]; then
     exit 1
 fi
 tar axf ${GNUEFI_BZ2}
-cd gnu-efi-3.0.9
+cd ${GNUEFI_NAME}
 make
 sudo $MAKE PREFIX=${PREFIX} install
 cd -

--- a/example/tcg2-get-caps.c
+++ b/example/tcg2-get-caps.c
@@ -6,7 +6,7 @@
 #include "tcg2-util.h"
 #include "util.h"
 
-void EFIAPI
+void
 tcg2_caps_prettyprint (EFI_TCG2_BOOT_SERVICE_CAPABILITY *caps)
 {
     Print (L"TPM2 Capabilities:\n");
@@ -35,7 +35,7 @@ tcg2_caps_prettyprint (EFI_TCG2_BOOT_SERVICE_CAPABILITY *caps)
     tcg2_algorithm_bitmap_prettyprint (caps->ActivePcrBanks);
 }
 
-EFI_STATUS EFIAPI
+EFI_STATUS
 get_capability_tcg2 (
     EFI_TCG2_PROTOCOL *tcg2_protocol,
     EFI_TCG2_BOOT_SERVICE_CAPABILITY *tcg2_bs_caps

--- a/example/util.c
+++ b/example/util.c
@@ -26,7 +26,7 @@ bitmap_val_str (UINT32 member, UINT32 selector)
     }
 }
 
-void EFIAPI
+void
 tcg2_algorithm_bitmap_prettyprint (EFI_TCG2_EVENT_ALGORITHM_BITMAP bitmap)
 {
     Print (L"    EFI_TCG2_BOOT_HASH_ALG_SHA1: %s\n",
@@ -40,7 +40,7 @@ tcg2_algorithm_bitmap_prettyprint (EFI_TCG2_EVENT_ALGORITHM_BITMAP bitmap)
     Print (L"    EFI_TCG2_BOOT_HASH_ALG_SM3_256: %s\n",
         bitmap_val_str (bitmap, EFI_TCG2_BOOT_HASH_ALG_SM3_256));
 }
-wchar_t* EFIAPI
+wchar_t*
 eventtype_to_string (TCG_EVENTTYPE event_type)
 {
     switch (event_type) {
@@ -124,7 +124,7 @@ get_alg_size (UINT16 alg_id)
         return 0;
     }
 }
-wchar_t* EFIAPI
+wchar_t*
 get_alg_name (UINT16 alg_id)
 {
     switch (alg_id) {
@@ -150,7 +150,7 @@ get_alg_name (UINT16 alg_id)
  * function will still return EFI_SUCCESS, but the 'format' parameter
  * will be set to 0.
  */
-EFI_STATUS EFIAPI
+EFI_STATUS
 get_eventlog_format_high (EFI_TCG2_PROTOCOL *tcg2_protocol,
                           EFI_TCG2_EVENT_LOG_FORMAT *format)
 {
@@ -172,24 +172,24 @@ get_eventlog_format_high (EFI_TCG2_PROTOCOL *tcg2_protocol,
     }
     return EFI_SUCCESS;
 }
-TCG_DIGEST2* EFIAPI
+TCG_DIGEST2*
 get_next_digest (TCG_DIGEST2* digest)
 {
     return (TCG_DIGEST2*)(digest->Digest + get_alg_size (digest->AlgorithmId));
 }
-bool EFIAPI
+bool
 is_pcr_selected (BYTE pcr_selection[],
                  uint8_t pcr)
 {
     return pcr_selection [pcr/8] & (1 << (pcr % 8));
 }
-void EFIAPI
+void
 select_pcr (BYTE pcr_selection [],
             uint8_t pcr)
 {
     pcr_selection [pcr/8] |= 1 << (pcr % 8);
 }
-void EFIAPI
+void
 deselect_pcr (BYTE pcr_selection [],
               uint8_t pcr)
 {
@@ -229,7 +229,7 @@ count_algs_in_bitmap (EFI_TCG2_EVENT_ALGORITHM_BITMAP bitmap)
     }
     return bitcount;
 }
-void EFIAPI
+void
 select_all_active_pcrs (EFI_TCG2_EVENT_ALGORITHM_BITMAP active_banks,
                         TPML_PCR_SELECTION *selections)
 {

--- a/example/util.h
+++ b/example/util.h
@@ -14,35 +14,35 @@ typedef bool (*PCR_SELECTION_CALLBACK) (TPMI_ALG_HASH alg,
 
 wchar_t*
 bitmap_val_str (UINT32 member, UINT32 selector);
-void EFIAPI
+void
 tcg2_algorithm_bitmap_prettyprint (EFI_TCG2_EVENT_ALGORITHM_BITMAP bitmap);
-wchar_t* EFIAPI
+wchar_t*
 eventtype_to_string (TCG_EVENTTYPE event_type);
-size_t EFIAPI
+size_t
 get_alg_size (UINT16 alg_id);
-wchar_t* EFIAPI
+wchar_t*
 get_alg_name (UINT16 alg_id);
-EFI_STATUS EFIAPI
+EFI_STATUS
 get_eventlog_format_high (EFI_TCG2_PROTOCOL *tcg2_protocol,
                           EFI_TCG2_EVENT_LOG_FORMAT *format);
-TCG_DIGEST2* EFIAPI
+TCG_DIGEST2*
 get_next_digest (TCG_DIGEST2* digest);
-bool EFIAPI
+bool
 is_pcr_selected (BYTE pcr_selection[],
                  uint8_t pcr);
-void EFIAPI
+void
 select_pcr (BYTE pcr_selection [],
             uint8_t pcr);
-void EFIAPI
+void
 deselect_pcr (BYTE pcr_selection [],
               uint8_t pcr);
 void
 foreach_selection (TPML_PCR_SELECTION *pcr_selection,
                    PCR_SELECTION_CALLBACK callback,
                    void *data);
-int EFIAPI
+int
 count_algs_in_bitmap (EFI_TCG2_EVENT_ALGORITHM_BITMAP bitmap);
-void EFIAPI
+void
 select_all_active_pcrs (EFI_TCG2_EVENT_ALGORITHM_BITMAP active_banks,
                         TPML_PCR_SELECTION *selections);
 void

--- a/src/tcg2-util.c
+++ b/src/tcg2-util.c
@@ -6,7 +6,7 @@
 
 #include "tcg2-protocol.h"
 
-EFI_STATUS EFIAPI
+EFI_STATUS
 tcg2_get_eventlog (EFI_TCG2_PROTOCOL *tpm2_prot,
                    EFI_TCG2_EVENT_LOG_FORMAT format,
                    EFI_PHYSICAL_ADDRESS *first,
@@ -29,7 +29,7 @@ tcg2_get_eventlog (EFI_TCG2_PROTOCOL *tpm2_prot,
     return status;
 }
 
-EFI_STATUS EFIAPI
+EFI_STATUS
 tcg2_get_active_pcr_banks (EFI_TCG2_PROTOCOL *tcg2_protocol,
                            UINT32 *pcr_banks)
 {
@@ -46,7 +46,7 @@ tcg2_get_active_pcr_banks (EFI_TCG2_PROTOCOL *tcg2_protocol,
     return status;
 }
 
-EFI_STATUS EFIAPI
+EFI_STATUS
 tcg2_get_capability (
     EFI_TCG2_PROTOCOL *tcg2_protocol,
     EFI_TCG2_BOOT_SERVICE_CAPABILITY *tcg2_bs_caps
@@ -65,7 +65,7 @@ tcg2_get_capability (
     return status;
 }
 
-UINT16 EFIAPI
+UINT16
 tcg2_get_max_buf (EFI_TCG2_PROTOCOL *tcg2_protocol)
 {
     EFI_TCG2_BOOT_SERVICE_CAPABILITY tcg2_bs_caps = {
@@ -86,7 +86,7 @@ tcg2_get_max_buf (EFI_TCG2_PROTOCOL *tcg2_protocol)
     }
 }
 
-EFI_STATUS EFIAPI
+EFI_STATUS
 tcg2_submit_command (EFI_TCG2_PROTOCOL *tcg2_protocol,
                      UINT32 input_size,
                      UINT8 *input_buf,
@@ -109,7 +109,7 @@ tcg2_submit_command (EFI_TCG2_PROTOCOL *tcg2_protocol,
     return status;
 }
 
-EFI_STATUS EFIAPI
+EFI_STATUS
 tcg2_get_protocol (EFI_TCG2_PROTOCOL **tcg2_protocol)
 {
     EFI_TCG2_PROTOCOL *tcg2_proto_tmp;

--- a/src/tcg2-util.h
+++ b/src/tcg2-util.h
@@ -6,29 +6,29 @@
 
 #include "tcg2-protocol.h"
 
-EFI_STATUS EFIAPI
+EFI_STATUS
 tcg2_get_eventlog (EFI_TCG2_PROTOCOL *tpm2_prot,
                    EFI_TCG2_EVENT_LOG_FORMAT format,
                    EFI_PHYSICAL_ADDRESS *first,
                    EFI_PHYSICAL_ADDRESS *last,
                    BOOLEAN *truncated);
-EFI_STATUS EFIAPI
+EFI_STATUS
 tcg2_get_active_pcr_banks (EFI_TCG2_PROTOCOL *tcg2_protocol,
                            UINT32 *pcr_banks);
-EFI_STATUS EFIAPI
+EFI_STATUS
 tcg2_get_capability (EFI_TCG2_PROTOCOL *tcg2_protocol,
                      EFI_TCG2_BOOT_SERVICE_CAPABILITY *tcg2_bs_caps);
-void EFIAPI
+void
 tcg2_caps_prettyprint (EFI_TCG2_BOOT_SERVICE_CAPABILITY *caps);
-UINT16 EFIAPI
+UINT16
 tcg2_get_max_buf (EFI_TCG2_PROTOCOL *tcg2_protocol);
-EFI_STATUS EFIAPI
+EFI_STATUS
 tcg2_submit_command (EFI_TCG2_PROTOCOL *tcg2_protocol,
                      UINT32 input_size,
                      UINT8 *input_buf,
                      UINT32 output_size,
                      UINT8 *output_buf);
-EFI_STATUS EFIAPI
+EFI_STATUS
 tcg2_get_protocol (EFI_TCG2_PROTOCOL **tcg2_protocol);
 
 #endif /* TCG2_UTIL_H */

--- a/src/tcti-uefi.c
+++ b/src/tcti-uefi.c
@@ -37,7 +37,7 @@ tcti_uefi_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
  * functions. This means we must keep a copy of the buffer in ternally so
  * that we can send it in the 'receive' function.
  */
-TSS2_RC EFIAPI
+TSS2_RC
 tcti_uefi_transmit (TSS2_TCTI_CONTEXT *context,
                     size_t size,
                     const uint8_t *command)
@@ -70,7 +70,7 @@ tcti_uefi_transmit (TSS2_TCTI_CONTEXT *context,
  * function can only doing blocking I/O. We transmit the stored
  * command buffer from the 'transmit' function.
  */
-TSS2_RC EFIAPI
+TSS2_RC
 tcti_uefi_receive (TSS2_TCTI_CONTEXT *context,
                    size_t *size,
                    uint8_t *response,
@@ -135,7 +135,7 @@ tcti_uefi_receive (TSS2_TCTI_CONTEXT *context,
  * Finalize function only validates the context structure before setting the
  * state to 'final'.
  */
-void EFIAPI
+void
 tcti_uefi_finalize (TSS2_TCTI_CONTEXT *context)
 {
     TSS2_TCTI_UEFI_CONTEXT *tcti_uefi;
@@ -174,7 +174,7 @@ sizeof_tcti_uefi_context (void)
 /*
  * Initialization function compliant with TCTI spec.
  */
-TSS2_RC
+TSS2_RC EFIAPI
 Tss2_Tcti_Uefi_Init (TSS2_TCTI_CONTEXT *context,
                      size_t *size,
                      const char *conf)

--- a/src/tss2-tcti-uefi.h
+++ b/src/tss2-tcti-uefi.h
@@ -3,13 +3,14 @@
 #define TSS2_TCTI_UEFI_H
 
 #include <tss2/tss2_tcti.h>
+#include <efi.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* TCTI specific / unique Init function. */
-TSS2_RC
+TSS2_RC EFIAPI
 Tss2_Tcti_Uefi_Init (TSS2_TCTI_CONTEXT *context,
                      size_t *size,
                      const char *conf);


### PR DESCRIPTION
Current use is inconsistent. AFAIK it's required only for the public
parts of the API. Integration with EDK2 will be definitive test.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>