### PR TITLE
example: Include 'util.h' as required for tcg2-get-pcr-banks.

### DIFF
--- a/example/tcg2-get-pcr-banks.c
+++ b/example/tcg2-get-pcr-banks.c
@@ -6,6 +6,7 @@
 #include <efi/efilib.h>
 
 #include "tcg2-util.h"
+#include "util.h"
 
 #define TRUE_STR L"true"
 #define FALSE_STR L"false"


### PR DESCRIPTION
This silences a compiler warning caused by a missing definition for the
'tcg2_algorithm_bitmap_prettyprint' function.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>