### PR TITLE
example: Fix bad return type on error path in util module.

### DIFF
--- a/example/util.c
+++ b/example/util.c
@@ -390,7 +390,7 @@ foreach_event2 (TCG_EVENT_HEADER2 *event_first,
     TCG_EVENT_HEADER2 *event;
 
     if (event_first == NULL || event_last == NULL || callback == NULL)
-        return NULL;
+        return false;
 
     for (event = event_first;
          event <= event_last && event != NULL;


### PR DESCRIPTION
When passed a bad parameter the 'foreach_event2' function previously
returned 'NULL' instead of 'false'. The end result is the same behavior
since 'NULL' is defined as 0, as is false. This is a semantic fix, an
important one though.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>