### PR TITLE
example: Remove unnecessary string.h include in example applications.

### DIFF
--- a/example/tcg2-get-pcr-banks.c
+++ b/example/tcg2-get-pcr-banks.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: BSD-2 */
 #include <inttypes.h>
-#include <string.h>
 
 #include <efi/efi.h>
 #include <efi/efilib.h>

--- a/example/tpm2-get-caps-fixed.c
+++ b/example/tpm2-get-caps-fixed.c
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: BSD-2 */
 #include <inttypes.h>
-#include <string.h>
 
 #include <efi/efi.h>
 #include <efi/efilib.h>


### PR DESCRIPTION
Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>