### PR TITLE
build: Restore use of timeout when running qemu to prevent hangs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
       env: SCANBUILD= CONFIG_EXTRA="--enable-code-coverage" MAKE_TARGET=check
 
 after_failure:
-  - cat tpm2-tcti-uefi-*/_build/sub/test-suite.log
+  - cat test-suite.log
 
 after_success:
   - |

--- a/lib/efi-test-setup.sh
+++ b/lib/efi-test-setup.sh
@@ -63,7 +63,7 @@ swtpm socket --tpm2 --tpmstate dir=${TMP_DIR} \
     --ctrl type=unixio,path=${TMP_DIR}/tpm-sock \
     --log file=${TMP_DIR}/${TEST_NAME}_swtpm.log,level=20 &
 
-qemu-system-x86_64 \
+timeout --preserve-status 30s unbuffer qemu-system-x86_64 \
     -nographic \
     --bios ${OVMF_FD} \
     -drive file=fat:rw:${TMP_DIR} \


### PR DESCRIPTION
This restores the old 30 second timeout, as well as the use of unbuffer.
Additionally this commit adds the use of '--preserve-status' to prevent
the build from ignoring failed tests that don't trigger the timeout.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>