### PR TITLE
Force gnu-efi and edk2 headers to coexist.

### DIFF
--- a/example/tcg2-get-caps.c
+++ b/example/tcg2-get-caps.c
@@ -1,6 +1,11 @@
 /* SPDX-License-Identifier: BSD-2 */
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
 #include <efi/efilib.h>
+#else
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#endif
 
 #include "tcg2-protocol.h"
 #include "tcg2-util.h"
@@ -35,6 +40,10 @@ tcg2_caps_prettyprint (EFI_TCG2_BOOT_SERVICE_CAPABILITY *caps)
     tcg2_algorithm_bitmap_prettyprint (caps->ActivePcrBanks);
 }
 
+#if !defined(uefi_call_wrapper)
+#define uefi_call_wrapper(func, va_num, ...) func(__VA_ARGS__)
+#endif
+
 EFI_STATUS
 get_capability_tcg2 (
     EFI_TCG2_PROTOCOL *tcg2_protocol,
@@ -66,7 +75,9 @@ efi_main (
         .Size = sizeof (EFI_TCG2_BOOT_SERVICE_CAPABILITY),
     };
 
+#ifndef EDK2_BUILD
     InitializeLib (ImageHandle, SystemTable);
+#endif
     status = tcg2_get_protocol (&tcg2_protocol);
     if (EFI_ERROR (status)) {
         return status;

--- a/example/tcg2-get-eventlog.c
+++ b/example/tcg2-get-eventlog.c
@@ -1,6 +1,12 @@
 /* SPDX-License-Identifier: BSD-2 */
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
 #include <efi/efilib.h>
+#else
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/ShellCommandLib.h>
+#endif
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -107,7 +113,9 @@ efi_main (
     EFI_TCG2_EVENT_LOG_FORMAT format = 0;
     BOOLEAN trunc;
 
+#ifndef EDK2_BUILD
     InitializeLib (ImageHandle, SystemTable);
+#endif
     status = tcg2_get_protocol (&tcg2_protocol);
     if (EFI_ERROR (status))
         return status;

--- a/example/tcg2-get-pcr-banks.c
+++ b/example/tcg2-get-pcr-banks.c
@@ -1,8 +1,14 @@
 /* SPDX-License-Identifier: BSD-2 */
-#include <inttypes.h>
-
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
 #include <efi/efilib.h>
+#else
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#endif
+
+#include <inttypes.h>
+#include <string.h>
 
 #include "tcg2-util.h"
 #include "util.h"
@@ -24,7 +30,9 @@ efi_main (
     EFI_TCG2_EVENT_ALGORITHM_BITMAP active_banks = 0;
     UINT8 proto_major, proto_minor;
 
+#ifndef EDK2_BUILD
     InitializeLib (ImageHandle, SystemTable);
+#endif
     status = tcg2_get_protocol (&tcg2_protocol);
     if (EFI_ERROR (status)) {
         return status;

--- a/example/tpm2-get-caps-fixed.c
+++ b/example/tpm2-get-caps-fixed.c
@@ -1,8 +1,14 @@
 /* SPDX-License-Identifier: BSD-2 */
-#include <inttypes.h>
-
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
 #include <efi/efilib.h>
+#else
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#endif
+
+#include <inttypes.h>
+#include <string.h>
 
 #include <tss2/tss2_mu.h>
 #include <tss2/tss2_sys.h>
@@ -276,7 +282,9 @@ efi_main (
     /* TPMS_CAPABILITY_DATA capability_data = { .capability = 0 }; */
     TPMS_CAPABILITY_DATA capability_data = { 0 };
 
+#ifndef EDK2_BUILD
     InitializeLib (ImageHandle, SystemTable);
+#endif
     rc = sys_uefi_init (&sys_ctx);
     if (rc != TSS2_RC_SUCCESS) {
         return EFI_ABORTED;

--- a/example/tpm2-get-pcrs.c
+++ b/example/tpm2-get-pcrs.c
@@ -1,6 +1,11 @@
 /* SPDX-License-Identifier: BSD-2 */
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
 #include <efi/efilib.h>
+#else
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#endif
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -102,7 +107,9 @@ efi_main (
     TSS2_RC rc;
     TSS2_SYS_CONTEXT *sys_ctx;
 
+#ifndef EDK2_BUILD
     InitializeLib (ImageHandle, SystemTable);
+#endif
     status = tcg2_get_protocol (&tcg2_protocol);
     if (EFI_ERROR (status)) {
         return status;

--- a/example/tss2-util.c
+++ b/example/tss2-util.c
@@ -1,6 +1,12 @@
 /* SPDX-License-Identifier: BSD-2 */
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
 #include <efi/efilib.h>
+#else
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/MemoryAllocationLib.h>
+#endif
 
 #include <tss2/tss2_tcti.h>
 #include <tss2/tss2_sys.h>

--- a/example/util.c
+++ b/example/util.c
@@ -1,6 +1,12 @@
 /* SPDX-License-Identifier: BSD-2 */
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
 #include <efi/efilib.h>
+#else
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/ShellCommandLib.h>
+#endif
 
 #include <inttypes.h>
 #include <stdlib.h>

--- a/example/util.h
+++ b/example/util.h
@@ -1,5 +1,10 @@
 /* SPDX-License-Identifier: BSD-2 */
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
+#else
+#include <Uefi.h>
+#endif
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <wchar.h>

--- a/src/tcg2-util.c
+++ b/src/tcg2-util.c
@@ -1,10 +1,20 @@
 /* SPDX-License-Identifier: BSD-2 */
 #include <inttypes.h>
 
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
 #include <efi/efilib.h>
-
+#else
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#define LibLocateProtocol(foo, bar) gBS->LocateProtocol(foo, NULL, bar)
+#endif
 #include "tcg2-protocol.h"
+
+#if !defined(uefi_call_wrapper)
+#define uefi_call_wrapper(func, va_num, ...) func(__VA_ARGS__)
+#endif
 
 EFI_STATUS
 tcg2_get_eventlog (EFI_TCG2_PROTOCOL *tpm2_prot,

--- a/src/tcg2-util.h
+++ b/src/tcg2-util.h
@@ -2,7 +2,11 @@
 #ifndef TCG2_UTIL_H
 #define TCG2_UTIL_H
 
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
+#else
+#include <Uefi.h>
+#endif
 
 #include "tcg2-protocol.h"
 

--- a/src/tcti-uefi.c
+++ b/src/tcti-uefi.c
@@ -1,12 +1,21 @@
 /* SPDX-License-Identifier: BSD-2 */
-#include <inttypes.h>
-
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
 #include <efi/efilib.h>
+#else
+#include <Uefi.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/UefiLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#define LibLocateProtocol(foo, bar) gBS->LocateProtocol(foo, NULL, bar)
+#endif
+
+#include <inttypes.h>
 
 #include <tss2/tss2_tpm2_types.h>
 #include <tss2/tss2_tcti.h>
 
+#include "tcg2-protocol.h"
 #include "tcg2-util.h"
 #include "tss2-tcti-uefi.h"
 #include "tcti-uefi.h"

--- a/src/tss2-tcti-uefi.h
+++ b/src/tss2-tcti-uefi.h
@@ -2,8 +2,13 @@
 #ifndef TSS2_TCTI_UEFI_H
 #define TSS2_TCTI_UEFI_H
 
+#ifndef EDK2_BUILD
+#include <efi/efi.h>
+#else
+#include <Uefi.h>
+#endif
+
 #include <tss2/tss2_tcti.h>
-#include <efi.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/uefi-types.h
+++ b/src/uefi-types.h
@@ -2,6 +2,7 @@
 #ifndef UEFI_TYPES_H
 #define UEFI_TYPES_H
 
+#ifndef EDK2_BUILD
 #if ARCH == x86_64
 #include <efi/x86_64/efibind.h>
 #elif ARCH == ia32
@@ -9,7 +10,7 @@
 #else
 #error "Unsupported ARCH."
 #endif
-
 #include <efi/efidef.h>
+#endif
 
 #endif /* UEFI_TYPES_H */

--- a/test/hello-world.c
+++ b/test/hello-world.c
@@ -1,6 +1,11 @@
 /* SPDX-License-Identifier: BSD-2 */
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
 #include <efi/efilib.h>
+#else
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#endif
 
 EFI_STATUS EFIAPI
 efi_main (
@@ -8,7 +13,9 @@ efi_main (
     EFI_SYSTEM_TABLE *SystemTable
     )
 {
+#ifndef EDK2_BUILD
     InitializeLib (ImageHandle, SystemTable);
+#endif
     Print (L"hello world!\n");
     return EFI_SUCCESS;
 }

--- a/test/tss2-mu-uint32.c
+++ b/test/tss2-mu-uint32.c
@@ -2,8 +2,13 @@
 #include <inttypes.h>
 #include <stdint.h>
 
+#ifndef EDK2_BUILD
 #include <efi/efi.h>
 #include <efi/efilib.h>
+#else
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#endif
 
 #include <tss2/tss2_mu.h>
 
@@ -17,7 +22,9 @@ efi_main (
     UINT32 tmp = 0xdeadbeef, tmp_marsh = 0;
     TSS2_RC rc;
 
+#ifndef EDK2_BUILD
     InitializeLib (ImageHandle, SystemTable);
+#endif
     Print (L"unmarshalled: 0x%" PRIx32 "\n", tmp);
     rc = Tss2_MU_UINT32_Marshal (tmp, (uint8_t*)&tmp_marsh, sizeof (tmp_marsh), &offset);
     if (rc != TSS2_RC_SUCCESS) {


### PR DESCRIPTION
We use autoconf to ensure that we have the required gnuefi headers when
building on Linux. When building under edk2 we don't have a
configuration phase and so we can't detect attributes of the build
environment before building. edk2 provides only static build metadata
files where we can set compiler / linker flags.

This patch introduces a new macro that the edk2 build metadata passes
to the compiler to indicate edk2 headers should be used (EDK2_BUILD).
We wrap the include directives for these headers in preprocessor
if/else/endif. If this macro is not defined then we assume we're
building under gnuefi.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>