### PR TITLE
tpm2-get-caps-fixed: Fixup for tpm-tool2 4.1.1 update

### DIFF
--- a/example/tpm2-get-caps-fixed.c
+++ b/example/tpm2-get-caps-fixed.c
@@ -140,11 +140,11 @@ dump_tpm_properties_fixed (TPMS_TAGGED_PROPERTY properties[],
             Print (L"TPM2_PT_INPUT_BUFFER:\n"
                     "  value: 0x%X\n", value);
             break;
-        case TPM2_PT_HR_TRANSIENT_MIN:
+        case TPM2_PT_TPM2_HR_TRANSIENT_MIN:
             Print (L"TPM2_PT_TPM2_HR_TRANSIENT_MIN:\n"
                     "  value: 0x%X\n", value);
             break;
-        case TPM2_PT_HR_PERSISTENT_MIN:
+        case TPM2_PT_TPM2_HR_PERSISTENT_MIN:
             Print (L"TPM2_PT_TPM2_HR_PERSISTENT_MIN:\n"
                     "  value: 0x%X\n", value);
             break;

--- a/src/uefi-types.h
+++ b/src/uefi-types.h
@@ -3,9 +3,9 @@
 #define UEFI_TYPES_H
 
 #ifndef EDK2_BUILD
-#if ARCH == x86_64
+#if defined(__x86_64__)
 #include <efi/x86_64/efibind.h>
-#elif ARCH == ia32
+#elif defined(__i386__)
 #include <efi/ia32/efibind.h>
 #else
 #error "Unsupported ARCH."


### PR DESCRIPTION
The tpm-tools 4.1.1 changes some defines so change to match

Signed-off-by: Armin Kuster <akuster808@gmail.com>